### PR TITLE
Use comments for the instructions to the author in the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,19 @@
 # Description
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
 
-Fixes # (issue)
-
-Depends on # (other pull requests)
-
+<!-- List any other pull requests that this change depends on. -->
 
 # How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
 
 - [ ] Tested on Hardware
 - [ ] Tested in Simulation
 
 **Test Configuration**:
-(add any information here if using a non typical setup)
+
+<!-- (add any information here if using a non typical setup) -->
 
 # Checklist:
 


### PR DESCRIPTION
# Description

This makes the instructions in the PR template into comments, so if someone doesn't delete them when they're creating the PR they won't appear in the body of the PR description.

# How Has This Been Tested?

I clicked the "preview" button on the template and made sure it looked like I'd expect.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
